### PR TITLE
Added Procedural Macro for Native Classes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2839,18 +2839,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/ion-proc/Cargo.toml
+++ b/ion-proc/Cargo.toml
@@ -8,7 +8,7 @@ license = "MPL-2.0"
 [dependencies]
 quote = "1.0.16"
 proc-macro2 = "1.0.36"
-syn = { version = "1.0.89", features = ["clone-impls", "full"] }
+syn = { version = "1.0.89", features = ["extra-traits", "full"] }
 
 [lib]
 proc-macro = true

--- a/ion-proc/src/class/accessor.rs
+++ b/ion-proc/src/class/accessor.rs
@@ -7,11 +7,88 @@
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 
-use proc_macro2::Ident;
-use syn::{Error, ItemFn, Result};
+use proc_macro2::{Ident, TokenStream};
+use syn::{Error, Expr, Field, Fields, ItemFn, ItemStruct, LitStr, Result, Visibility};
 
-use crate::class::Accessor;
 use crate::class::method::impl_method;
+
+#[derive(Debug)]
+pub(crate) struct Accessor(Option<ItemFn>, Option<ItemFn>);
+
+impl Accessor {
+	pub(crate) fn from_field(field: &mut Field, class: Ident) -> Result<Option<Accessor>> {
+		let krate = quote!(::ion);
+		if let Visibility::Public(_) = field.vis {
+			let ident = field.ident.as_ref().unwrap().clone();
+			let ty = field.ty.clone();
+			let mut convert = None;
+
+			let mut index = None;
+			for (i, attr) in field.attrs.iter().enumerate() {
+				if attr.path == parse_quote!(convert) {
+					index = Some(i);
+					let convert_ty: Expr = attr.parse_args()?;
+					convert = Some(convert_ty);
+				}
+			}
+			if let Some(index) = index {
+				field.attrs.remove(index);
+			}
+			let convert = convert.unwrap_or(parse_quote!(()));
+
+			let getter_ident = Ident::new(&format!("get_{}", ident), ident.span());
+			let setter_ident = Ident::new(&format!("set_{}", ident), ident.span());
+
+			let getter = parse_quote!(
+				fn #getter_ident(#[this] this: &#class) -> #krate::Result<#ty> {
+					Ok(this.#ident)
+				}
+			);
+			let setter = parse_quote!(
+				fn #setter_ident(#[this] this: &mut #class, #[convert(#convert)] #ident: #ty) -> #krate::Result<()> {
+					this.#ident = #ident;
+					Ok(())
+				}
+			);
+
+			let (getter, _) = impl_accessor(&getter, false)?;
+			let (setter, _) = impl_accessor(&setter, true)?;
+
+			Ok(Some(Accessor(Some(getter), Some(setter))))
+		} else {
+			Ok(None)
+		}
+	}
+
+	pub(crate) fn to_spec(&self, name: Ident) -> TokenStream {
+		let krate = quote!(::ion);
+		let Accessor(getter, setter) = self;
+		if let Some(getter) = getter {
+			let getter = getter.sig.ident.clone();
+			let name = LitStr::new(&name.to_string(), name.span());
+			if let Some(setter) = setter {
+				let setter = setter.sig.ident.clone();
+				quote!(#krate::property_spec_getter_setter!(#getter, #setter, #name, #krate::flags::PropertyFlags::CONSTANT_ENUMERATED))
+			} else {
+				quote!(#krate::property_spec_getter!(#getter, #name, #krate::flags::PropertyFlags::CONSTANT_ENUMERATED))
+			}
+		} else if let Some(setter) = setter {
+			let setter = setter.sig.ident.clone();
+			let name = LitStr::new(&name.to_string(), name.span());
+			quote!(#krate::property_spec_setter!(#setter, #name, #krate::flags::PropertyFlags::CONSTANT_ENUMERATED))
+		} else {
+			let name = LitStr::new(&format!("{}\0", name.to_string()), name.span());
+			quote!(
+				#krate::spec::create_property_spec_accessor(
+					::std::concat!(#name, "\0"),
+					::mozjs::jsapi::JSNativeWrapper { op: None, info: ::std::ptr::null_mut() },
+					::mozjs::jsapi::JSNativeWrapper { op: None, info: ::std::ptr::null_mut() },
+					#krate::flags::PropertyFlags::CONSTANT_ENUMERATED,
+				)
+			)
+		}
+	}
+}
 
 pub(crate) fn get_accessor_name(ident: &Ident, is_setter: bool) -> String {
 	let mut name = ident.to_string();
@@ -36,21 +113,40 @@ pub(crate) fn impl_accessor(method: &ItemFn, is_setter: bool) -> Result<(ItemFn,
 pub(crate) fn insert_accessor(accessors: &mut HashMap<String, Accessor>, name: String, getter: Option<ItemFn>, setter: Option<ItemFn>) {
 	match accessors.entry(name) {
 		Entry::Occupied(mut o) => match (getter, setter) {
-			(Some(g), Some(s)) => *o.get_mut() = (Some(g), Some(s)),
+			(Some(g), Some(s)) => *o.get_mut() = Accessor(Some(g), Some(s)),
 			(Some(g), None) => o.get_mut().0 = Some(g),
 			(None, Some(s)) => o.get_mut().1 = Some(s),
 			(None, None) => {}
 		},
 		Entry::Vacant(v) => {
-			v.insert((getter, setter));
-		},
+			v.insert(Accessor(getter, setter));
+		}
 	}
 }
 
 pub(crate) fn flatten_accessors(accessors: HashMap<String, Accessor>) -> Vec<ItemFn> {
 	accessors
 		.into_iter()
-		.flat_map(|(_, (getter, setter))| [getter, setter])
+		.flat_map(|(_, Accessor(getter, setter))| [getter, setter])
 		.filter_map(|p| p)
 		.collect()
+}
+
+pub(crate) fn insert_property_accessors(accessors: &mut HashMap<String, Accessor>, class: &mut ItemStruct) -> Result<()> {
+	match &mut class.fields {
+		Fields::Named(fields) => {
+			fields
+				.named
+				.iter_mut()
+				.map(|field| {
+					if let Some(accessor) = Accessor::from_field(field, class.ident.clone())? {
+						accessors.insert(field.ident.as_ref().unwrap().to_string(), accessor);
+					}
+					Ok(())
+				})
+				.collect::<Result<_>>()?;
+		}
+		_ => {}
+	}
+	Ok(())
 }

--- a/ion-proc/src/class/accessor.rs
+++ b/ion-proc/src/class/accessor.rs
@@ -1,0 +1,56 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+
+use proc_macro2::Ident;
+use syn::{Error, ItemFn, Result};
+
+use crate::class::Accessor;
+use crate::class::method::impl_method;
+
+pub(crate) fn get_accessor_name(ident: &Ident, is_setter: bool) -> String {
+	let mut name = ident.to_string();
+	let pat = if is_setter { "set_" } else { "get_" };
+	if name.starts_with(pat) {
+		name.drain(0..4);
+	}
+	name
+}
+
+pub(crate) fn impl_accessor(method: &ItemFn, is_setter: bool) -> Result<(ItemFn, bool)> {
+	let expected_args = if is_setter { 1 } else { 0 };
+	let error_message = if is_setter {
+		format!("Expected Setter to have {} argument", expected_args)
+	} else {
+		format!("Expected Getter to have {} arguments", expected_args)
+	};
+	let error = Error::new_spanned(&method.sig, error_message);
+	impl_method(method.clone(), |nargs| (nargs == expected_args).then(|| ()).ok_or(error)).map(|(method, _, this)| (method, this.is_some()))
+}
+
+pub(crate) fn insert_accessor(accessors: &mut HashMap<String, Accessor>, name: String, getter: Option<ItemFn>, setter: Option<ItemFn>) {
+	match accessors.entry(name) {
+		Entry::Occupied(mut o) => match (getter, setter) {
+			(Some(g), Some(s)) => *o.get_mut() = (Some(g), Some(s)),
+			(Some(g), None) => o.get_mut().0 = Some(g),
+			(None, Some(s)) => o.get_mut().1 = Some(s),
+			(None, None) => {}
+		},
+		Entry::Vacant(v) => {
+			v.insert((getter, setter));
+		},
+	}
+}
+
+pub(crate) fn flatten_accessors(accessors: HashMap<String, Accessor>) -> Vec<ItemFn> {
+	accessors
+		.into_iter()
+		.flat_map(|(_, (getter, setter))| [getter, setter])
+		.filter_map(|p| p)
+		.collect()
+}

--- a/ion-proc/src/class/constructor.rs
+++ b/ion-proc/src/class/constructor.rs
@@ -1,0 +1,90 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+use proc_macro2::{Ident, TokenStream};
+use syn::{Block, ItemFn, Result};
+
+use crate::function::{check_abi, set_signature};
+use crate::function::inner::{DefaultInnerBody, impl_inner_fn, InnerBody};
+
+pub(crate) fn impl_constructor(mut constructor: ItemFn) -> Result<(ItemFn, usize)> {
+	let krate = quote!(::ion);
+	let (mut inner, nargs, _) = impl_inner_fn::<ClassConstructorInnerBody>(&constructor, true)?;
+
+	inner.sig.output = parse_quote!(-> #krate::Result<()>);
+
+	check_abi(&mut constructor)?;
+	set_signature(&mut constructor)?;
+	constructor.attrs.push(parse_quote!(#[allow(non_snake_case)]));
+
+	let error_handler = error_handler();
+
+	let body = parse_quote!({
+		let args = #krate::Arguments::new(argc, vp);
+
+		if !args.is_constructing() {
+			#krate::Error::Error(String::from("Constructor must be called with \"new\".")).throw(cx);
+			return false;
+		}
+
+		#inner
+
+		let result = ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| native_fn(cx, &args)));
+
+		#error_handler
+	});
+	constructor.block = Box::new(body);
+
+	Ok((constructor, nargs))
+}
+
+pub(crate) struct ClassConstructorInnerBody;
+
+impl InnerBody for ClassConstructorInnerBody {
+	fn impl_inner(body: Box<Block>, this: Option<Ident>, is_async: bool) -> TokenStream {
+		let body = DefaultInnerBody::impl_inner(body, this.clone(), is_async);
+		quote!(
+			let result = #body;
+
+			use ::mozjs::conversions::ToJSValConvertible;
+
+			result.map(|result| unsafe {
+				let b = ::std::boxed::Box::new(result);
+				::mozjs::rooted!(in(cx) let this = ::mozjs::jsapi::JS_NewObjectForConstructor(cx, &CLASS, &args.call_args()));
+				::mozjs::jsapi::SetPrivate(this.get(), Box::leak(b) as *mut _ as *mut ::std::ffi::c_void);
+				this.get().to_jsval(cx, ::mozjs::rust::MutableHandle::from_raw(args.rval()));
+			})
+		)
+	}
+}
+
+pub(crate) fn error_handler() -> TokenStream {
+	let krate = quote!(::ion);
+	quote!({
+		use ::std::prelude::v1::*;
+
+		match result {
+			Ok(Ok(_)) => {
+				true
+			},
+			Ok(Err(error)) => {
+				error.throw(cx);
+				false
+			}
+			Err(unwind_error) => {
+				if let Some(unwind) = unwind_error.downcast_ref::<String>() {
+					#krate::Error::Error(unwind.clone()).throw(cx);
+				} else if let Some(unwind) = unwind_error.downcast_ref::<&str>() {
+					#krate::Error::Error(String::from(*unwind)).throw(cx);
+				} else {
+					#krate::Error::Error(String::from("Unknown Panic Occurred")).throw(cx);
+					::std::mem::forget(unwind_error);
+				}
+				false
+			}
+		}
+	})
+}

--- a/ion-proc/src/class/method.rs
+++ b/ion-proc/src/class/method.rs
@@ -1,0 +1,35 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+use proc_macro2::Ident;
+use syn::{ItemFn, Result};
+
+use crate::function::{check_abi, error_handler, set_signature};
+use crate::function::inner::{DefaultInnerBody, impl_inner_fn};
+
+pub(crate) fn impl_method(mut method: ItemFn) -> Result<(ItemFn, usize, Option<Ident>)> {
+	let krate = quote!(::ion);
+	let (inner, nargs, this) = impl_inner_fn::<DefaultInnerBody>(&method, true)?;
+
+	check_abi(&mut method)?;
+	set_signature(&mut method)?;
+	method.attrs.push(parse_quote!(#[allow(non_snake_case)]));
+
+	let error_handler = error_handler();
+
+	let body = parse_quote!({
+		let args = #krate::Arguments::new(argc, vp);
+
+		#inner
+
+		let result = ::std::panic::catch_unwind(::std::panic::AssertUnwindSafe(|| native_fn(cx, &args)));
+
+		#error_handler
+	});
+	method.block = Box::new(body);
+
+	Ok((method, nargs, this))
+}

--- a/ion-proc/src/class/method.rs
+++ b/ion-proc/src/class/method.rs
@@ -5,16 +5,16 @@
  */
 
 use proc_macro2::Ident;
-use syn::{ItemFn, Result};
+use syn::{ItemFn, Result, Signature};
 
 use crate::function::{check_abi, error_handler, set_signature};
 use crate::function::inner::{DefaultInnerBody, impl_inner_fn};
 
-pub(crate) fn impl_method<F: FnOnce(usize) -> Result<()>>(mut method: ItemFn, predicate: F) -> Result<(ItemFn, usize, Option<Ident>)> {
+pub(crate) fn impl_method<F: FnOnce(&Signature) -> Result<()>>(mut method: ItemFn, predicate: F) -> Result<(ItemFn, usize, Option<Ident>)> {
 	let krate = quote!(::ion);
 	let (inner, nargs, this) = impl_inner_fn::<DefaultInnerBody>(&method, true)?;
 
-	predicate(nargs).and_then(|_| {
+	predicate(&method.sig).and_then(|_| {
 		check_abi(&mut method)?;
 		set_signature(&mut method)?;
 		method.attrs.push(parse_quote!(#[allow(non_snake_case)]));

--- a/ion-proc/src/class/mod.rs
+++ b/ion-proc/src/class/mod.rs
@@ -11,7 +11,7 @@ use quote::ToTokens;
 use syn::{Error, ImplItem, Item, ItemFn, ItemMod, parse, Result, Visibility};
 use syn::spanned::Spanned;
 
-use crate::class::accessor::{flatten_accessors, get_accessor_name, impl_accessor, insert_accessor};
+use crate::class::accessor::{flatten_accessors, get_accessor_name, impl_accessor, insert_accessor, insert_property_accessors};
 use crate::class::constructor::impl_constructor;
 use crate::class::method::impl_method;
 use crate::class::property::Property;
@@ -22,8 +22,6 @@ pub(crate) mod constructor;
 pub(crate) mod method;
 pub(crate) mod property;
 pub(crate) mod statics;
-
-pub(crate) type Accessor = (Option<ItemFn>, Option<ItemFn>);
 
 pub(crate) fn impl_js_class(mut module: ItemMod) -> Result<TokenStream> {
 	let content = &mut module.content.as_mut().unwrap().1;
@@ -146,7 +144,9 @@ pub(crate) fn impl_js_class(mut module: ItemMod) -> Result<TokenStream> {
 	if class.is_none() {
 		return Err(Error::new(module.span(), "Expected Struct within Module"));
 	}
-	let class = class.unwrap();
+	let mut class = class.unwrap();
+
+	insert_property_accessors(&mut accessors, &mut class)?;
 
 	if constructor.is_none() {
 		return Err(Error::new(module.span(), "Expected Constructor within Module"));

--- a/ion-proc/src/class/mod.rs
+++ b/ion-proc/src/class/mod.rs
@@ -1,0 +1,240 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+use proc_macro2::{Ident, TokenStream};
+use quote::ToTokens;
+use syn::{Error, ImplItem, Item, ItemFn, ItemMod, ItemStatic, ItemStruct, LitStr, parse, Result, Visibility};
+use syn::spanned::Spanned;
+
+use crate::class::constructor::impl_constructor;
+use crate::class::method::impl_method;
+use crate::class::property::Property;
+
+pub(crate) mod constructor;
+pub(crate) mod method;
+pub(crate) mod property;
+
+pub(crate) fn impl_js_class(mut module: ItemMod) -> Result<TokenStream> {
+	let krate = quote!(::ion);
+	let content = &mut module.content.as_mut().unwrap().1;
+
+	let mut object = None;
+	let mut constructor = None;
+	let mut regular_impl = None;
+	let mut methods = Vec::new();
+	let mut static_methods = Vec::new();
+	let mut static_properties = Vec::new();
+
+	let mut content_to_remove = Vec::new();
+	for (i, item) in content.iter().enumerate() {
+		content_to_remove.push(i);
+		match item {
+			Item::Struct(str) if object.is_none() => object = Some(str.clone()),
+			Item::Impl(imp) => {
+				let object = object.as_ref().map(|o| {
+					let ident = o.ident.clone();
+					parse_quote!(#ident)
+				});
+				if Some(&*imp.self_ty) == object.as_ref() {
+					let mut impl_items_to_remove = Vec::new();
+					let mut imp = imp.clone();
+
+					for (j, item) in imp.items.iter().enumerate() {
+						impl_items_to_remove.push(j);
+						match item {
+							ImplItem::Method(method) => {
+								let mut method: ItemFn = parse(method.to_token_stream().into())?;
+								let mut constructor_index = None;
+								for (i, attr) in method.attrs.iter().enumerate() {
+									if attr == &parse_quote!(#[constructor]) {
+										constructor_index = Some(i);
+									}
+								}
+
+								if let Some(index) = constructor_index {
+									method.attrs.remove(index);
+									constructor = Some(impl_constructor(method.clone())?);
+									continue;
+								}
+
+								let (method, nargs, this) = impl_method(method.clone())?;
+
+								if this.is_some() {
+									methods.push((method, nargs));
+								} else {
+									static_methods.push((method, nargs));
+								}
+							}
+							ImplItem::Const(con) => {
+								impl_items_to_remove.pop();
+								if let Visibility::Public(_) = con.vis {
+									if let Some(property) = Property::from_const(&con) {
+										static_properties.push(property);
+									}
+								}
+							}
+							_ => {
+								impl_items_to_remove.pop();
+							}
+						}
+					}
+
+					impl_items_to_remove.reverse();
+					for index in impl_items_to_remove {
+						imp.items.remove(index);
+					}
+
+					regular_impl = Some(imp);
+				} else {
+					content_to_remove.pop();
+				}
+			}
+			_ => {
+				content_to_remove.pop();
+			}
+		}
+	}
+
+	content_to_remove.reverse();
+	for index in content_to_remove {
+		content.remove(index);
+	}
+
+	if object.is_none() {
+		return Err(Error::new(module.span(), "Expected Struct within Module"));
+	}
+	let object = object.unwrap();
+
+	if constructor.is_none() {
+		return Err(Error::new(module.span(), "Expected Constructor within Module"));
+	}
+	let (constructor, constructor_nargs) = constructor.unwrap();
+	let constructor_ident = constructor.sig.ident.clone();
+	let constructor_nargs = constructor_nargs as u32;
+
+	let class = js_class(&object);
+	let class_name = object.ident.clone();
+
+	let methods_array = js_methods(&methods, false);
+	let static_methods_array = js_methods(&static_methods, true);
+	let static_properties_array = js_properties(static_properties, true, &class_name);
+
+	let methods: Vec<_> = methods.into_iter().map(|(m, _)| m).collect();
+	let static_methods: Vec<_> = static_methods.into_iter().map(|(m, _)| m).collect();
+
+	let class_initialiser = parse_quote!(
+		impl #krate::ClassInitialiser for #class_name {
+			fn class() -> &'static ::mozjs::jsapi::JSClass {
+				&CLASS
+			}
+
+			fn constructor() -> (::ion::NativeFunction, u32) {
+				(#constructor_ident, #constructor_nargs)
+			}
+
+			fn functions() -> &'static [::mozjs::jsapi::JSFunctionSpec] {
+				&FUNCTIONS
+			}
+
+			fn static_functions() -> &'static [::mozjs::jsapi::JSFunctionSpec] {
+				&STATIC_FUNCTIONS
+			}
+
+			fn static_properties() -> &'static [::mozjs::jsapi::JSPropertySpec] {
+				&STATIC_PROPERTIES
+			}
+		}
+	);
+
+	content.push(Item::Struct(object));
+	if let Some(regular_impl) = regular_impl {
+		content.push(Item::Impl(regular_impl));
+	}
+	content.push(Item::Fn(constructor));
+	for method in methods {
+		content.push(Item::Fn(method));
+	}
+	for method in static_methods {
+		content.push(Item::Fn(method));
+	}
+	content.push(Item::Static(class));
+	content.push(Item::Static(methods_array));
+	content.push(Item::Static(static_methods_array));
+	content.push(Item::Static(static_properties_array));
+	content.push(Item::Impl(class_initialiser));
+
+	Ok(module.to_token_stream())
+}
+
+pub(crate) fn js_class(object: &ItemStruct) -> ItemStatic {
+	let krate = quote!(::ion);
+	let name = format!("{}\0", object.ident);
+	let name = LitStr::new(&name, object.ident.span());
+
+	parse_quote!(
+		static CLASS: ::mozjs::jsapi::JSClass = ::mozjs::jsapi::JSClass {
+			name: #name.as_ptr() as *const i8,
+			flags: #krate::class_reserved_slots(0),
+			cOps: ::std::ptr::null_mut(),
+			spec: ::std::ptr::null_mut(),
+			ext: ::std::ptr::null_mut(),
+			oOps: ::std::ptr::null_mut(),
+		};
+	)
+}
+
+pub(crate) fn js_methods(methods: &[(ItemFn, usize)], stat: bool) -> ItemStatic {
+	let krate = quote!(::ion);
+	let ident: Ident = if stat { parse_quote!(STATIC_FUNCTIONS) } else { parse_quote!(FUNCTIONS) };
+	let specs: Vec<_> = methods
+		.into_iter()
+		.map(|(method, nargs)| {
+			let name = LitStr::new(&method.sig.ident.to_string(), method.sig.ident.span());
+			let ident = method.sig.ident.clone();
+			let nargs = *nargs as u16;
+			quote!(#krate::function_spec!(#ident, #name, #nargs, #krate::flags::PropertyFlags::CONSTANT))
+		})
+		.collect();
+
+	if specs.is_empty() {
+		parse_quote!(
+			static #ident: &[::mozjs::jsapi::JSFunctionSpec] = &[
+				::mozjs::jsapi::JSFunctionSpec::ZERO,
+			];
+		)
+	} else {
+		parse_quote!(
+			static #ident: &[::mozjs::jsapi::JSFunctionSpec] = &[
+				#(#specs),*,
+				::mozjs::jsapi::JSFunctionSpec::ZERO,
+			];
+		)
+	}
+}
+
+pub(crate) fn js_properties(properties: Vec<Property>, stat: bool, class: &Ident) -> ItemStatic {
+	let ident: Ident = if stat {
+		parse_quote!(STATIC_PROPERTIES)
+	} else {
+		parse_quote!(PROPERTIES)
+	};
+
+	let specs: Vec<_> = properties.into_iter().map(|property| property.into_spec(class.clone())).collect();
+	if specs.is_empty() {
+		parse_quote!(
+			static #ident: &[::mozjs::jsapi::JSPropertySpec] = &[
+				::mozjs::jsapi::JSPropertySpec::ZERO,
+			];
+		)
+	} else {
+		parse_quote!(
+			static #ident: &[::mozjs::jsapi::JSPropertySpec] = &[
+				#(#specs),*,
+				::mozjs::jsapi::JSPropertySpec::ZERO,
+			];
+		)
+	}
+}

--- a/ion-proc/src/class/property.rs
+++ b/ion-proc/src/class/property.rs
@@ -6,9 +6,7 @@
 
 use proc_macro2::{Ident, TokenStream};
 use syn::{ImplItemConst, LitStr, Type};
-use syn::spanned::Spanned;
 
-use crate::class::Accessor;
 use crate::utils::type_ends_with;
 
 #[derive(Clone, Debug)]
@@ -59,34 +57,5 @@ impl Property {
 				quote!(#krate::spec::create_property_spec_string(#name, #class::#ident, #krate::flags::PropertyFlags::CONSTANT_ENUMERATED))
 			}
 		}
-	}
-}
-
-pub(crate) fn accessor_to_spec(accessor: &Accessor, name: &str) -> TokenStream {
-	let krate = quote!(::ion);
-	let (getter, setter) = accessor;
-	if let Some(getter) = getter {
-		let getter = getter.sig.ident.clone();
-		let name = LitStr::new(&name.to_string(), name.span());
-		if let Some(setter) = setter {
-			let setter = setter.sig.ident.clone();
-			quote!(#krate::property_spec_getter_setter!(#getter, #setter, #name, #krate::flags::PropertyFlags::CONSTANT_ENUMERATED))
-		} else {
-			quote!(#krate::property_spec_getter!(#getter, #name, #krate::flags::PropertyFlags::CONSTANT_ENUMERATED))
-		}
-	} else if let Some(setter) = setter {
-		let setter = setter.sig.ident.clone();
-		let name = LitStr::new(&name.to_string(), name.span());
-		quote!(#krate::property_spec_setter!(#setter, #name, #krate::flags::PropertyFlags::CONSTANT_ENUMERATED))
-	} else {
-		let name = LitStr::new(&format!("{}\0", name.to_string()), name.span());
-		quote!(
-			#krate::spec::create_property_spec_accessor(
-				::std::concat!(#name, "\0"),
-				::mozjs::jsapi::JSNativeWrapper { op: None, info: ::std::ptr::null_mut() },
-				::mozjs::jsapi::JSNativeWrapper { op: None, info: ::std::ptr::null_mut() },
-				#krate::flags::PropertyFlags::CONSTANT_ENUMERATED,
-			)
-		)
 	}
 }

--- a/ion-proc/src/class/property.rs
+++ b/ion-proc/src/class/property.rs
@@ -6,7 +6,9 @@
 
 use proc_macro2::{Ident, TokenStream};
 use syn::{ImplItemConst, LitStr, Type};
+use syn::spanned::Spanned;
 
+use crate::class::Accessor;
 use crate::utils::type_ends_with;
 
 #[derive(Clone, Debug)]
@@ -40,7 +42,7 @@ impl Property {
 		}
 	}
 
-	pub(crate) fn into_spec(self, class: Ident) -> TokenStream {
+	pub(crate) fn to_spec(&self, class: Ident) -> TokenStream {
 		let krate = quote!(::ion);
 		match self {
 			Property::Int32(ident) => {
@@ -57,5 +59,34 @@ impl Property {
 				quote!(#krate::spec::create_property_spec_string(#name, #class::#ident, #krate::flags::PropertyFlags::CONSTANT_ENUMERATED))
 			}
 		}
+	}
+}
+
+pub(crate) fn accessor_to_spec(accessor: &Accessor, name: &str) -> TokenStream {
+	let krate = quote!(::ion);
+	let (getter, setter) = accessor;
+	if let Some(getter) = getter {
+		let getter = getter.sig.ident.clone();
+		let name = LitStr::new(&name.to_string(), name.span());
+		if let Some(setter) = setter {
+			let setter = setter.sig.ident.clone();
+			quote!(#krate::property_spec_getter_setter!(#getter, #setter, #name, #krate::flags::PropertyFlags::CONSTANT_ENUMERATED))
+		} else {
+			quote!(#krate::property_spec_getter!(#getter, #name, #krate::flags::PropertyFlags::CONSTANT_ENUMERATED))
+		}
+	} else if let Some(setter) = setter {
+		let setter = setter.sig.ident.clone();
+		let name = LitStr::new(&name.to_string(), name.span());
+		quote!(#krate::property_spec_setter!(#setter, #name, #krate::flags::PropertyFlags::CONSTANT_ENUMERATED))
+	} else {
+		let name = LitStr::new(&format!("{}\0", name.to_string()), name.span());
+		quote!(
+			#krate::spec::create_property_spec_accessor(
+				::std::concat!(#name, "\0"),
+				::mozjs::jsapi::JSNativeWrapper { op: None, info: ::std::ptr::null_mut() },
+				::mozjs::jsapi::JSNativeWrapper { op: None, info: ::std::ptr::null_mut() },
+				#krate::flags::PropertyFlags::CONSTANT_ENUMERATED,
+			)
+		)
 	}
 }

--- a/ion-proc/src/class/property.rs
+++ b/ion-proc/src/class/property.rs
@@ -1,0 +1,61 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+use proc_macro2::{Ident, TokenStream};
+use syn::{ImplItemConst, LitStr, Type};
+
+use crate::utils::type_ends_with;
+
+#[derive(Clone, Debug)]
+pub(crate) enum Property {
+	Int32(Ident),
+	Double(Ident),
+	String(Ident),
+}
+
+impl Property {
+	pub(crate) fn from_const(con: &ImplItemConst) -> Option<Property> {
+		match &con.ty {
+			Type::Path(ty) => {
+				if type_ends_with(&ty, "i32") {
+					Some(Property::Int32(con.ident.clone()))
+				} else if type_ends_with(&ty, "f64") {
+					Some(Property::Double(con.ident.clone()))
+				} else {
+					None
+				}
+			}
+			Type::Reference(re) => {
+				if let Type::Path(ty) = &*re.elem {
+					if type_ends_with(&ty, "str") {
+						return Some(Property::String(con.ident.clone()));
+					}
+				}
+				None
+			}
+			_ => None,
+		}
+	}
+
+	pub(crate) fn into_spec(self, class: Ident) -> TokenStream {
+		let krate = quote!(::ion);
+		match self {
+			Property::Int32(ident) => {
+				let name = LitStr::new(&(format!("{}\0", ident)), ident.span());
+				quote!(#krate::spec::create_property_spec_int(#name, #class::#ident, #krate::flags::PropertyFlags::CONSTANT_ENUMERATED))
+			}
+			Property::Double(ident) => {
+				let name = LitStr::new(&(format!("{}\0", ident)), ident.span());
+				quote!(#krate::spec::create_property_spec_double(#name, #class::#ident, #krate::flags::PropertyFlags::CONSTANT_ENUMERATED))
+			}
+			Property::String(ident) => {
+				let name = LitStr::new(&(format!("{}\0", ident)), ident.span());
+				// TODO: Null-Terminate Constant
+				quote!(#krate::spec::create_property_spec_string(#name, #class::#ident, #krate::flags::PropertyFlags::CONSTANT_ENUMERATED))
+			}
+		}
+	}
+}

--- a/ion-proc/src/class/statics.rs
+++ b/ion-proc/src/class/statics.rs
@@ -9,8 +9,8 @@ use std::collections::HashMap;
 use proc_macro2::Ident;
 use syn::{ItemFn, ItemImpl, ItemStatic, ItemStruct, LitStr};
 
-use crate::class::Accessor;
-use crate::class::property::{accessor_to_spec, Property};
+use crate::class::accessor::Accessor;
+use crate::class::property::Property;
 
 pub(crate) fn class_spec(object: &ItemStruct) -> ItemStatic {
 	let krate = quote!(::ion);
@@ -57,7 +57,9 @@ pub(crate) fn properties_to_specs(properties: &[Property], accessors: &HashMap<S
 	};
 
 	let mut specs: Vec<_> = properties.into_iter().map(|property| property.to_spec(class.clone())).collect();
-	accessors.iter().for_each(|(name, accessor)| specs.push(accessor_to_spec(accessor, name)));
+	accessors
+		.iter()
+		.for_each(|(name, accessor)| specs.push(accessor.to_spec(Ident::new(name, class.span()))));
 
 	specs.push(quote!(::mozjs::jsapi::JSPropertySpec::ZERO));
 

--- a/ion-proc/src/class/statics.rs
+++ b/ion-proc/src/class/statics.rs
@@ -1,0 +1,101 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+use std::collections::HashMap;
+
+use proc_macro2::Ident;
+use syn::{ItemFn, ItemImpl, ItemStatic, ItemStruct, LitStr};
+
+use crate::class::Accessor;
+use crate::class::property::{accessor_to_spec, Property};
+
+pub(crate) fn class_spec(object: &ItemStruct) -> ItemStatic {
+	let krate = quote!(::ion);
+	let name = LitStr::new(&format!("{}\0", object.ident), object.ident.span());
+
+	parse_quote!(
+		static CLASS: ::mozjs::jsapi::JSClass = ::mozjs::jsapi::JSClass {
+			name: #name.as_ptr() as *const i8,
+			flags: #krate::class_reserved_slots(0),
+			cOps: ::std::ptr::null_mut(),
+			spec: ::std::ptr::null_mut(),
+			ext: ::std::ptr::null_mut(),
+			oOps: ::std::ptr::null_mut(),
+		};
+	)
+}
+
+pub(crate) fn methods_to_specs(methods: &[(ItemFn, usize)], stat: bool) -> ItemStatic {
+	let krate = quote!(::ion);
+	let ident = if stat { quote!(STATIC_FUNCTIONS) } else { quote!(FUNCTIONS) };
+	let mut specs: Vec<_> = methods
+		.into_iter()
+		.map(|(method, nargs)| {
+			let name = LitStr::new(&method.sig.ident.to_string(), method.sig.ident.span());
+			let ident = method.sig.ident.clone();
+			let nargs = *nargs as u16;
+			quote!(#krate::function_spec!(#ident, #name, #nargs, #krate::flags::PropertyFlags::CONSTANT))
+		})
+		.collect();
+	specs.push(quote!(::mozjs::jsapi::JSFunctionSpec::ZERO));
+
+	parse_quote!(
+		static #ident: &[::mozjs::jsapi::JSFunctionSpec] = &[
+			#(#specs),*
+		];
+	)
+}
+
+pub(crate) fn properties_to_specs(properties: &[Property], accessors: &HashMap<String, Accessor>, class: &Ident, stat: bool) -> ItemStatic {
+	let ident: Ident = if stat {
+		parse_quote!(STATIC_PROPERTIES)
+	} else {
+		parse_quote!(PROPERTIES)
+	};
+
+	let mut specs: Vec<_> = properties.into_iter().map(|property| property.to_spec(class.clone())).collect();
+	accessors.iter().for_each(|(name, accessor)| specs.push(accessor_to_spec(accessor, name)));
+
+	specs.push(quote!(::mozjs::jsapi::JSPropertySpec::ZERO));
+
+	parse_quote!(
+		static #ident: &[::mozjs::jsapi::JSPropertySpec] = &[
+			#(#specs),*
+		];
+	)
+}
+
+pub(crate) fn class_initialiser(name: Ident, constructor: (Ident, u32)) -> ItemImpl {
+	let krate = quote!(::ion);
+	let (ident, nargs) = constructor;
+	parse_quote!(
+		impl #krate::ClassInitialiser for #name {
+			fn class() -> &'static ::mozjs::jsapi::JSClass {
+				&CLASS
+			}
+
+			fn constructor() -> (::ion::NativeFunction, u32) {
+				(#ident, #nargs)
+			}
+
+			fn functions() -> &'static [::mozjs::jsapi::JSFunctionSpec] {
+				&FUNCTIONS
+			}
+
+			fn properties() -> &'static [::mozjs::jsapi::JSPropertySpec] {
+				&PROPERTIES
+			}
+
+			fn static_functions() -> &'static [::mozjs::jsapi::JSFunctionSpec] {
+				&STATIC_FUNCTIONS
+			}
+
+			fn static_properties() -> &'static [::mozjs::jsapi::JSPropertySpec] {
+				&STATIC_PROPERTIES
+			}
+		}
+	)
+}

--- a/ion-proc/src/function/parameters.rs
+++ b/ion-proc/src/function/parameters.rs
@@ -107,7 +107,7 @@ impl Parameter {
 	pub(crate) fn is_normal(&self) -> bool {
 		if let Parameter::Normal(ty, _) = self {
 			if let Type::Path(ty) = &*ty.ty {
-				return type_ends_with(ty, "Option");
+				return !type_ends_with(ty, "Option");
 			}
 		}
 		false

--- a/ion-proc/src/function/parameters.rs
+++ b/ion-proc/src/function/parameters.rs
@@ -28,10 +28,10 @@ impl Parameter {
 			} else {
 				let mut convert = None;
 				let mut vararg = false;
-				for attr in arg.attrs.clone() {
-					if attr == parse_quote!(#[this]) {
+				for attr in &arg.attrs {
+					if attr == &parse_quote!(#[this]) {
 						return Ok(Parameter::This(arg.clone()));
-					} else if attr == parse_quote!(#[varargs]) {
+					} else if attr == &parse_quote!(#[varargs]) {
 						vararg = true;
 					} else if attr.path == parse_quote!(convert) {
 						let convert_ty: Expr = attr.parse_args()?;
@@ -40,9 +40,9 @@ impl Parameter {
 				}
 
 				if vararg {
-					Ok(Parameter::VarArgs(arg.clone(), Box::new(convert.unwrap_or_else(|| parse_quote!(())))))
+					Ok(Parameter::VarArgs(arg.clone(), Box::new(convert.unwrap_or(parse_quote!(())))))
 				} else {
-					Ok(Parameter::Normal(arg.clone(), Box::new(convert.unwrap_or_else(|| parse_quote!(())))))
+					Ok(Parameter::Normal(arg.clone(), Box::new(convert.unwrap_or(parse_quote!(())))))
 				}
 			};
 		}

--- a/ion-proc/src/lib.rs
+++ b/ion-proc/src/lib.rs
@@ -12,17 +12,34 @@ extern crate syn;
 use proc_macro::TokenStream;
 
 use quote::ToTokens;
-use syn::ItemFn;
+use syn::{Error, ItemFn, ItemMod};
 
+use crate::class::impl_js_class;
 use crate::function::impl_js_fn;
 
-mod function;
+pub(crate) mod class;
+pub(crate) mod function;
+pub(crate) mod utils;
 
 #[proc_macro_attribute]
 pub fn js_fn(_attr: TokenStream, stream: TokenStream) -> TokenStream {
 	let function = parse_macro_input!(stream as ItemFn);
 
 	match impl_js_fn(function) {
+		Ok(function) => TokenStream::from(function.to_token_stream()),
+		Err(error) => TokenStream::from(error.to_compile_error()),
+	}
+}
+
+#[proc_macro_attribute]
+pub fn js_class(_attr: TokenStream, stream: TokenStream) -> TokenStream {
+	let module = parse_macro_input!(stream as ItemMod);
+	if module.content.is_none() {
+		let error = Error::new_spanned(module, "Expected Non-Empty Module");
+		return TokenStream::from(error.to_compile_error());
+	}
+
+	match impl_js_class(module) {
 		Ok(function) => TokenStream::from(function.to_token_stream()),
 		Err(error) => TokenStream::from(error.to_compile_error()),
 	}

--- a/ion-proc/src/utils.rs
+++ b/ion-proc/src/utils.rs
@@ -1,0 +1,15 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+use syn::TypePath;
+
+pub(crate) fn type_ends_with(ty: &TypePath, ident: &str) -> bool {
+	if let Some(last) = ty.path.segments.last() {
+		last.ident == ident
+	} else {
+		false
+	}
+}

--- a/ion/src/class.rs
+++ b/ion/src/class.rs
@@ -1,0 +1,106 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+use std::any::TypeId;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::ptr;
+
+use mozjs::jsapi::{JS_GetConstructor, JS_InitClass, JSClass, JSFunctionSpec, JSPropertySpec};
+use mozjs_sys::jsapi::{JS_GetInstancePrivate, JSObject};
+
+use crate::{Arguments, Context, Function, NativeFunction, Object};
+
+// TODO: Move into Context Wrapper
+thread_local!(pub static CLASS_INFOS: RefCell<HashMap<TypeId, ClassInfo>> = RefCell::new(HashMap::new()));
+
+#[derive(Copy, Clone, Debug)]
+pub struct ClassInfo {
+	constructor: Function,
+	prototype: Object,
+}
+
+pub trait ClassInitialiser {
+	fn class() -> &'static JSClass;
+
+	fn parent_info(_: Context) -> Option<ClassInfo> {
+		None
+	}
+
+	fn constructor() -> (NativeFunction, u32);
+
+	fn functions() -> &'static [JSFunctionSpec] {
+		&[JSFunctionSpec::ZERO]
+	}
+
+	fn properties() -> &'static [JSPropertySpec] {
+		&[JSPropertySpec::ZERO]
+	}
+
+	fn static_functions() -> &'static [JSFunctionSpec] {
+		&[JSFunctionSpec::ZERO]
+	}
+
+	fn static_properties() -> &'static [JSPropertySpec] {
+		&[JSPropertySpec::ZERO]
+	}
+
+	fn init_class(cx: Context, object: &Object) -> ClassInfo
+	where
+		Self: Sized + 'static,
+	{
+		let class = Self::class();
+		let parent_proto = Self::parent_info(cx).map(|ci| ci.prototype).unwrap_or(Object::new(cx));
+		let (constructor, nargs) = Self::constructor();
+		let properties = Self::properties();
+		let functions = Self::functions();
+		let static_properties = Self::static_properties();
+		let static_functions = Self::static_functions();
+
+		rooted!(in(cx) let parent_prototype = *parent_proto);
+		rooted!(in(cx) let object = **object);
+		let class = unsafe {
+			JS_InitClass(
+				cx,
+				object.handle().into(),
+				parent_prototype.handle().into(),
+				class,
+				Some(constructor),
+				nargs,
+				properties.as_ptr() as *const _,
+				functions.as_ptr() as *const _,
+				static_properties.as_ptr() as *const _,
+				static_functions.as_ptr() as *const _,
+			)
+		};
+
+		rooted!(in(cx) let rclass = class);
+		let constructor = unsafe { JS_GetConstructor(cx, rclass.handle().into()) };
+
+		let class_info = ClassInfo {
+			constructor: Function::from_object(constructor).unwrap(),
+			prototype: Object::from(class),
+		};
+
+		CLASS_INFOS.with(|infos| {
+			let mut infos = infos.borrow_mut();
+			(*infos).insert(TypeId::of::<Self>(), class_info);
+			class_info
+		})
+	}
+
+	fn get_private<'a>(cx: Context, obj: *mut JSObject, args: Option<&Arguments>) -> &'a mut Self
+	where
+		Self: Sized,
+	{
+		unsafe {
+			rooted!(in(cx) let obj = obj);
+			let args = args.map(|a| a.call_args()).as_mut().map_or(ptr::null_mut(), |args| args);
+			let ptr = JS_GetInstancePrivate(cx, obj.handle().into(), Self::class(), args) as *mut Self;
+			&mut *ptr
+		}
+	}
+}

--- a/ion/src/flags.rs
+++ b/ion/src/flags.rs
@@ -12,7 +12,7 @@ use mozjs::jsapi::{
 bitflags! {
 	/// Represents the flags of properties on an [Object](crate::Object)
 	pub struct PropertyFlags: u16 {
-		/// Prevents enumeration through `Object.keys()`, `for...in` and other functions.
+		/// Allows enumeration through `Object.keys()`, `for...in` and other functions.
 		/// See [Enumerability of Properties](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties#traversing_object_properties) for more information
 		const ENUMERATE = JSPROP_ENUMERATE as u16;
 		/// Prevents reassignment of the property.

--- a/ion/src/format/primitive.rs
+++ b/ion/src/format/primitive.rs
@@ -39,6 +39,8 @@ pub fn format_primitive(cx: Context, cfg: Config, value: JSVal) -> String {
 		"null".color(colors.null).to_string()
 	} else if value.is_undefined() {
 		"undefined".color(colors.undefined).to_string()
+	} else if value.is_magic() {
+		"<magic>".color(colors.boolean).to_string()
 	} else {
 		unreachable!("Internal Error: Expected Primitive")
 	}

--- a/ion/src/lib.rs
+++ b/ion/src/lib.rs
@@ -13,6 +13,7 @@ use std::result::Result as Result2;
 
 use mozjs::jsapi::JSContext;
 
+pub use class::ClassInitialiser;
 pub use error::Error;
 pub use exception::*;
 pub use functions::*;
@@ -20,6 +21,7 @@ pub use ion_proc::*;
 pub use objects::*;
 pub use value::Value;
 
+mod class;
 mod error;
 mod exception;
 pub mod flags;

--- a/modules/src/url/url.rs
+++ b/modules/src/url/url.rs
@@ -249,9 +249,7 @@ unsafe fn format(cx: Context, #[this] this: Object, options: Option<Object>) -> 
 	let mut url = get_url(cx, this);
 
 	let auth = options.and_then(|options| options.get_as::<bool>(cx, "auth", ())).unwrap_or(true);
-	let fragment = options
-		.and_then(|options| options.get_as::<bool>(cx, "fragment", ()))
-		.unwrap_or(true);
+	let fragment = options.and_then(|options| options.get_as::<bool>(cx, "fragment", ())).unwrap_or(true);
 	let search = options.and_then(|options| options.get_as::<bool>(cx, "search", ())).unwrap_or(true);
 
 	if !auth {

--- a/modules/src/url/url.rs
+++ b/modules/src/url/url.rs
@@ -4,265 +4,210 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-use std::cmp::Ordering;
-use std::ptr;
-
 use idna::{domain_to_ascii, domain_to_unicode};
-use mozjs::conversions::{jsstr_to_string, ToJSValConvertible};
-use mozjs::conversions::ConversionBehavior::EnforceRange;
-use mozjs::glue::JS_GetReservedSlot;
-use mozjs::jsapi::{HandleObject, JS_InitClass, JS_NewObjectForConstructor, JS_SetReservedSlot, JSClass, JSFunctionSpec, JSPropertySpec};
-use mozjs::jsval::{JSVal, NullValue};
-use url::Url;
+use mozjs::jsapi::JSFunctionSpec;
 
-use ion::{Arguments, class_reserved_slots, Context, Error, Object, Result};
-use ion::flags::PropertyFlags;
+use ion::{Context, Error, Object, Result};
+use ion::ClassInitialiser;
 use runtime::modules::NativeModule;
 
-unsafe fn get_url(cx: Context, this: Object) -> Url {
-	let mut value = NullValue();
-	JS_GetReservedSlot(*this, 0, &mut value);
-	Url::parse(&jsstr_to_string(cx, value.to_string())).unwrap()
-}
+#[js_class]
+mod class {
+	use std::cmp::Ordering;
 
-unsafe fn set_url(cx: Context, this: Object, url: Url) {
-	rooted!(in(cx) let mut string = NullValue());
-	url.to_string().to_jsval(cx, string.handle_mut());
-	JS_SetReservedSlot(*this, 0, &string.get());
-}
+	use mozjs::conversions::ConversionBehavior::EnforceRange;
+	use url::Url;
 
-#[js_fn]
-unsafe fn constructor(cx: Context, args: &Arguments, input: String, base: Option<String>) -> Result<Object> {
-	if !args.is_constructing() {
-		return Err(Error::Error(String::from("This constructor must be called with \"new\".")));
+	use ion::{Error, Object, Result};
+
+	pub struct URL {
+		url: Url,
 	}
-	let options = Url::options();
-	let base = base.as_ref().and_then(|base| Url::parse(base).ok());
-	options.base_url(base.as_ref());
-	match options.parse(&input) {
-		Ok(url) => {
-			rooted!(in(cx) let this = JS_NewObjectForConstructor(cx, &URL_CLASS, &args.call_args()));
-			set_url(cx, Object::from(this.get()), url);
-			Ok(Object::from(this.get()))
+
+	impl URL {
+		#[constructor]
+		fn constructor(input: String, base: Option<String>) -> Result<URL> {
+			let options = Url::options();
+			let base = base.as_ref().and_then(|base| Url::parse(base).ok());
+			options.base_url(base.as_ref());
+			options.parse(&input).map_err(|error| Error::Error(error.to_string()))
 		}
-		Err(error) => Err(Error::Error(error.to_string())),
-	}
-}
 
-#[js_fn]
-unsafe fn href(#[this] this: Object) -> Result<JSVal> {
-	let mut value = NullValue();
-	JS_GetReservedSlot(*this, 0, &mut value);
-	Ok(value)
-}
-
-#[js_fn]
-unsafe fn protocol(cx: Context, #[this] this: Object) -> Result<String> {
-	let url = get_url(cx, this);
-	Ok(format!("{}:", url.scheme()))
-}
-
-#[js_fn]
-unsafe fn host(cx: Context, #[this] this: Object) -> Result<Option<String>> {
-	let url = get_url(cx, this);
-	let host = url.host_str().map(|host| {
-		if let Some(port) = url.port() {
-			format!("{}:{}", host, port)
-		} else {
-			String::from(host)
+		fn origin(#[this] this: &URL) -> Result<String> {
+			Ok(this.url.origin().ascii_serialization())
 		}
-	});
-	Ok(host)
-}
 
-#[js_fn]
-unsafe fn hostname(cx: Context, #[this] this: Object) -> Result<Option<String>> {
-	let url = get_url(cx, this);
-	Ok(url.host_str().map(String::from))
-}
+		fn toString(#[this] this: &URL) -> Result<String> {
+			Ok(this.url.to_string())
+		}
 
-#[js_fn]
-unsafe fn port(cx: Context, #[this] this: Object) -> Result<Option<u16>> {
-	let url = get_url(cx, this);
-	Ok(url.port_or_known_default())
-}
+		fn toJSON(#[this] this: &URL) -> Result<String> {
+			Ok(this.url.to_string())
+		}
 
-#[js_fn]
-unsafe fn path(cx: Context, #[this] this: Object) -> Result<String> {
-	let url = get_url(cx, this);
-	Ok(String::from(url.path()))
-}
+		// TODO: Add Error Bubbling (Replace `let _ = {...}`)
+		fn format(#[this] this: &URL, options: Option<Object>) -> Result<String> {
+			let mut url = this.url.clone();
 
-#[js_fn]
-unsafe fn username(cx: Context, #[this] this: Object) -> Result<String> {
-	let url = get_url(cx, this);
-	Ok(String::from(url.username()))
-}
+			let auth = options.and_then(|options| options.get_as::<bool>(cx, "auth", ())).unwrap_or(true);
+			let fragment = options.and_then(|options| options.get_as::<bool>(cx, "fragment", ())).unwrap_or(true);
+			let search = options.and_then(|options| options.get_as::<bool>(cx, "search", ())).unwrap_or(true);
 
-#[js_fn]
-unsafe fn password(cx: Context, #[this] this: Object) -> Result<Option<String>> {
-	let url = get_url(cx, this);
-	Ok(url.password().map(String::from))
-}
+			if !auth {
+				let _ = url.set_username("");
+			}
+			if !fragment {
+				url.set_fragment(None);
+			}
+			if !search {
+				url.set_query(None);
+			}
 
-#[js_fn]
-unsafe fn search(cx: Context, #[this] this: Object) -> Result<Option<String>> {
-	let url = get_url(cx, this);
-	Ok(url.query().map(String::from))
-}
+			Ok(url.to_string())
+		}
 
-#[js_fn]
-unsafe fn hash(cx: Context, #[this] this: Object) -> Result<Option<String>> {
-	let url = get_url(cx, this);
-	Ok(url.fragment().map(String::from))
-}
+		#[get]
+		fn get_href(#[this] this: &URL) -> Result<String> {
+			Ok(this.url.to_string())
+		}
 
-#[js_fn]
-unsafe fn set_href(cx: Context, #[this] this: Object, input: String) -> Result<()> {
-	match Url::parse(&input) {
-		Ok(url) => {
-			set_url(cx, this, url);
+		#[set]
+		fn set_href(#[this] this: &mut URL, input: String) -> Result<()> {
+			match Url::parse(&input) {
+				Ok(url) => {
+					this.url = url;
+					Ok(())
+				}
+				Err(error) => Err(Error::Error(error.to_string())),
+			}
+		}
+
+		#[get]
+		fn get_protocol(#[this] this: &URL) -> Result<String> {
+			Ok(String::from(this.url.scheme()))
+		}
+
+		#[set]
+		fn set_protocol(#[this] this: &mut URL, protocol: String) -> Result<()> {
+			this.url.set_scheme(&protocol).map_err(|_| Error::Error(String::from("Invalid Protocol")))
+		}
+
+		#[get]
+		fn get_host(#[this] this: &URL) -> Result<Option<String>> {
+			let host = this.url.host_str().map(|host| {
+				if let Some(port) = this.url.port() {
+					format!("{}:{}", host, port)
+				} else {
+					String::from(host)
+				}
+			});
+			Ok(host)
+		}
+
+		// TODO: Add Error Bubbling (Replace `let _ = {...}`)
+		#[set]
+		fn set_host(#[this] this: &mut URL, host: Option<String>) -> Result<()> {
+			if let Some(host) = host {
+				let segments: Vec<&str> = host.split(':').collect();
+				let (host, port) = match segments.len().cmp(&2) {
+					Ordering::Less => (segments[0], None),
+					Ordering::Greater => return Err(Error::Error(String::from("Invalid Host"))),
+					Ordering::Equal => {
+						let port = match segments[1].parse::<u16>() {
+							Ok(port) => port,
+							Err(error) => return Err(Error::Error(error.to_string())),
+						};
+						(segments[0], Some(port))
+					}
+				};
+
+				if let Err(error) = this.url.set_host(Some(host)) {
+					return Err(Error::Error(error.to_string()));
+				}
+
+				let _ = this.url.set_port(port);
+			} else {
+				let _ = this.url.set_host(None);
+				let _ = this.url.set_port(None);
+			}
 			Ok(())
 		}
-		Err(error) => Err(Error::Error(error.to_string())),
-	}
-}
 
-#[js_fn]
-unsafe fn set_protocol(cx: Context, #[this] this: Object, protocol: String) -> Result<()> {
-	let mut url = get_url(cx, this);
-	let result = url.set_scheme(&protocol).map_err(|_| Error::Error(String::from("Invalid Protocol")));
-	set_url(cx, this, url);
-	result
-}
-
-#[js_fn]
-unsafe fn set_host(cx: Context, #[this] this: Object, host: Option<String>) -> Result<()> {
-	let mut url = get_url(cx, this);
-
-	if let Some(host) = host {
-		let segments: Vec<&str> = host.split(':').collect();
-		let (host, port) = match segments.len().cmp(&2) {
-			Ordering::Less => (segments[0], None),
-			Ordering::Greater => return Err(Error::Error(String::from("Invalid Host"))),
-			Ordering::Equal => {
-				let port = match segments[1].parse::<u16>() {
-					Ok(port) => port,
-					Err(error) => return Err(Error::Error(error.to_string())),
-				};
-				(segments[0], Some(port))
-			}
-		};
-
-		if let Err(error) = url.set_host(Some(host)) {
-			return Err(Error::Error(error.to_string()));
+		#[get]
+		fn get_hostname(#[this] this: &URL) -> Result<Option<String>> {
+			Ok(this.url.host_str().map(String::from))
 		}
 
-		let _ = url.set_port(port);
-	} else {
-		let _ = url.set_host(None);
-		let _ = url.set_port(None);
+		#[set]
+		fn set_hostname(#[this] this: &mut URL, hostname: Option<String>) -> Result<()> {
+			this.url.set_host(hostname.as_deref()).map_err(|error| Error::Error(error.to_string()))
+		}
+
+		#[get]
+		fn get_port(#[this] this: &URL) -> Result<Option<u16>> {
+			Ok(this.url.port_or_known_default())
+		}
+
+		#[set]
+		fn set_port(#[this] this: &mut URL, #[convert(EnforceRange)] port: Option<u16>) -> Result<()> {
+			this.url.set_port(port).map_err(|_| Error::Error(String::from("Invalid Port")))
+		}
+
+		#[get]
+		fn get_path(#[this] this: &URL) -> Result<String> {
+			Ok(String::from(this.url.path()))
+		}
+
+		#[set]
+		fn set_path(#[this] this: &mut URL, path: String) -> Result<()> {
+			this.url.set_path(&path);
+			Ok(())
+		}
+
+		#[get]
+		fn get_username(#[this] this: &URL) -> Result<String> {
+			Ok(String::from(this.url.username()))
+		}
+
+		#[set]
+		fn set_username(#[this] this: &mut URL, username: String) -> Result<()> {
+			this.url.set_username(&username).map_err(|_| Error::Error(String::from("Invalid URL")))
+		}
+
+		#[get]
+		fn get_password(#[this] this: &URL) -> Result<Option<String>> {
+			Ok(this.url.password().map(String::from))
+		}
+
+		#[set]
+		fn set_password(#[this] this: &mut URL, password: Option<String>) -> Result<()> {
+			this.url
+				.set_password(password.as_deref())
+				.map_err(|_| Error::Error(String::from("Invalid URL")))
+		}
+
+		#[get]
+		fn get_search(#[this] this: &URL) -> Result<Option<String>> {
+			Ok(this.url.query().map(String::from))
+		}
+
+		#[set]
+		fn set_search(#[this] this: &mut URL, search: Option<String>) -> Result<()> {
+			this.url.set_query(search.as_deref());
+			Ok(())
+		}
+
+		#[get]
+		fn get_hash(#[this] this: &URL) -> Result<Option<String>> {
+			Ok(this.url.fragment().map(String::from))
+		}
+
+		#[set]
+		fn set_hash(#[this] this: &mut URL, hash: Option<String>) -> Result<()> {
+			this.url.set_fragment(hash.as_deref());
+			Ok(())
+		}
 	}
-
-	set_url(cx, this, url);
-	Ok(())
-}
-
-#[js_fn]
-unsafe fn set_hostname(cx: Context, #[this] this: Object, hostname: Option<String>) -> Result<()> {
-	let mut url = get_url(cx, this);
-	let result = url.set_host(hostname.as_deref()).map_err(|error| Error::Error(error.to_string()));
-	set_url(cx, this, url);
-	result
-}
-
-#[js_fn]
-unsafe fn set_port(cx: Context, #[this] this: Object, #[convert(EnforceRange)] port: Option<u16>) -> Result<()> {
-	let mut url = get_url(cx, this);
-	let _ = url.set_port(port);
-	set_url(cx, this, url);
-	Ok(())
-}
-
-#[js_fn]
-unsafe fn set_path(cx: Context, #[this] this: Object, input: String) -> Result<()> {
-	let mut url = get_url(cx, this);
-	url.set_path(&input);
-	set_url(cx, this, url);
-	Ok(())
-}
-
-#[js_fn]
-unsafe fn set_username(cx: Context, #[this] this: Object, input: String) -> Result<()> {
-	let mut url = get_url(cx, this);
-	let _ = url.set_username(&input);
-	set_url(cx, this, url);
-	Ok(())
-}
-
-#[js_fn]
-unsafe fn set_password(cx: Context, #[this] this: Object, input: Option<String>) -> Result<()> {
-	let mut url = get_url(cx, this);
-	let _ = url.set_password(input.as_deref());
-	set_url(cx, this, url);
-	Ok(())
-}
-
-#[js_fn]
-unsafe fn set_search(cx: Context, #[this] this: Object, input: Option<String>) -> Result<()> {
-	let mut url = get_url(cx, this);
-	url.set_query(input.as_deref());
-	set_url(cx, this, url);
-	Ok(())
-}
-
-#[js_fn]
-unsafe fn set_hash(cx: Context, #[this] this: Object, input: Option<String>) -> Result<()> {
-	let mut url = get_url(cx, this);
-	url.set_fragment(input.as_deref());
-	set_url(cx, this, url);
-	Ok(())
-}
-
-#[js_fn]
-unsafe fn origin(cx: Context, #[this] this: Object) -> Result<String> {
-	let url = get_url(cx, this);
-	Ok(url.origin().ascii_serialization())
-}
-
-#[js_fn]
-unsafe fn toString(#[this] this: Object) -> Result<JSVal> {
-	let mut value = NullValue();
-	JS_GetReservedSlot(*this, 0, &mut value);
-	Ok(value)
-}
-
-#[js_fn]
-unsafe fn toJSON(#[this] this: Object) -> Result<JSVal> {
-	let mut value = NullValue();
-	JS_GetReservedSlot(*this, 0, &mut value);
-	Ok(value)
-}
-
-#[js_fn]
-unsafe fn format(cx: Context, #[this] this: Object, options: Option<Object>) -> Result<String> {
-	let mut url = get_url(cx, this);
-
-	let auth = options.and_then(|options| options.get_as::<bool>(cx, "auth", ())).unwrap_or(true);
-	let fragment = options.and_then(|options| options.get_as::<bool>(cx, "fragment", ())).unwrap_or(true);
-	let search = options.and_then(|options| options.get_as::<bool>(cx, "search", ())).unwrap_or(true);
-
-	if !auth {
-		let _ = url.set_username("");
-	}
-	if !fragment {
-		url.set_fragment(None);
-	}
-	if !search {
-		url.set_query(None);
-	}
-
-	Ok(url.to_string())
 }
 
 #[js_fn]
@@ -274,37 +219,6 @@ fn domainToASCII(domain: String) -> Result<String> {
 fn domainToUnicode(domain: String) -> Result<String> {
 	Ok(domain_to_unicode(&domain).0)
 }
-
-static PROPERTIES: &[JSPropertySpec] = &[
-	property_spec_getter_setter!(href, set_href),
-	property_spec_getter_setter!(protocol, set_protocol),
-	property_spec_getter_setter!(host, set_host),
-	property_spec_getter_setter!(hostname, set_hostname),
-	property_spec_getter_setter!(port, set_port),
-	property_spec_getter_setter!(path, set_path),
-	property_spec_getter_setter!(username, set_username),
-	property_spec_getter_setter!(password, set_password),
-	property_spec_getter_setter!(search, set_search),
-	property_spec_getter_setter!(hash, set_hash),
-	property_spec_getter!(origin),
-	JSPropertySpec::ZERO,
-];
-
-static METHODS: &[JSFunctionSpec] = &[
-	function_spec!(toString, "toString", 0, PropertyFlags::CONSTANT),
-	function_spec!(toJSON, "toJSON", 0, PropertyFlags::CONSTANT),
-	function_spec!(format, "format", 0, PropertyFlags::CONSTANT),
-	JSFunctionSpec::ZERO,
-];
-
-static URL_CLASS: JSClass = JSClass {
-	name: "URL\0".as_ptr() as *const i8,
-	flags: class_reserved_slots(1),
-	cOps: ptr::null_mut(),
-	spec: ptr::null_mut(),
-	ext: ptr::null_mut(),
-	oOps: ptr::null_mut(),
-};
 
 const FUNCTIONS: &[JSFunctionSpec] = &[function_spec!(domainToASCII, 0), function_spec!(domainToUnicode, 0), JSFunctionSpec::ZERO];
 
@@ -318,24 +232,8 @@ impl NativeModule for UrlM {
 	fn module(cx: Context) -> Option<Object> {
 		let mut url = Object::new(cx);
 		if url.define_methods(cx, FUNCTIONS) {
-			rooted!(in(cx) let urlr = *url);
-			let class = unsafe {
-				JS_InitClass(
-					cx,
-					urlr.handle().into(),
-					HandleObject::null(),
-					&URL_CLASS,
-					Some(constructor),
-					1,
-					PROPERTIES.as_ptr() as *const _,
-					METHODS.as_ptr() as *const _,
-					ptr::null_mut(),
-					ptr::null_mut(),
-				)
-			};
-			if !class.is_null() {
-				return Some(url);
-			}
+			class::URL::init_class(cx, &url);
+			return Some(url);
 		}
 		None
 	}


### PR DESCRIPTION
Resolves: #9 

The addition of this new procedural macro allows easier creation of native functions to reduce boilerplate and chances for type errors.
It currently supports:

- Methods
- Accessors
- Accessors for Public Properties
- Static Methods,
- Static Value Properties
- Static Accessors

Below is an example of code using this macro:
```rs
#[ion::js_class]
mod switch {
	use ion::Result;
	use mozjs::conversions::ConversionBehavior::Clamp;

	#[derive(Clone, Debug)]
	pub struct Switch {
		b: bool,
		#[convert(Clamp)]
		pub i: i32,
	}

	impl Switch {
		pub const INT: i32 = 32;
		pub const DOUBLE: f64 = 4.20;
		pub const STRING: &'static str = "SPIDER\0";

		#[constructor]
		fn new(b: bool) -> Result<Switch> {
			Ok(Switch { b, i: 144 })
		}

		fn print(#[this] this: &mut Switch) -> Result<()> {
			eprintln!("SWITCH: {:?}", this);
			Ok(())
		}

		fn switch(#[this] this: &mut Switch) -> Result<()> {
			this.b = !this.b;
			Ok(())
		}

		fn spiderfire() -> Result<String> {
			Ok(String::from("SPIDERFIRE"))
		}

		#[get]
		fn b(#[this] this: &Switch) -> Result<bool> {
			Ok(this.b)
		}

		#[set]
		fn set_b(#[this] this: &mut Switch, b: bool) -> Result<()> {
			this.b = b;
			Ok(())
		}

		#[get]
		fn get_a() -> Result<i32> {
			Ok(Switch::INT)
		}

		#[set]
		fn c(_: bool) -> Result<()> {
			eprintln!("Pranked!");
			Ok(())
		}
	}
}
```

The rough equivalent of this code in TypeScript would be
```ts
class Switch {
	static INT = 32;
	static DOUBLE = 4.20;
	static STRING = "SPIDER";
	
	constructor(b: boolean) {
		self._b = b;
		self._i = 144;
	}
	
	print() {
		console.log(this);
	}
	
	switch() {
		this.b = !this.b;
	}
	
	static spiderfire() {
		return "SPIDERFIRE";
	}
	
	get b() {
		return this._b;
	}
	
	set b(b: boolean) {
		this.b = b;
	}
	
	static get a() {
		return Switch.INT;
	}
	
	static set c(_: any) {
		console.log("Pranked!");
	}
	
	get i() {
		return this._i;
	}
	
	set i(i: number) {
		this._i = i;
	}
}
```