### PR TITLE
CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Get LLVM version from rustc
         run: |
-          echo "LLVM_VERSION=$(rustc -vV | sed -n 's|LLVM version: ||p' | cut -d. -f1)" >> $GITHUB_ENV
+          echo "LLVM_VERSION=$(rustc -vV | sed -n 's|LLVM version: ||p')" >> $GITHUB_ENV
         shell: bash
         
       - name: Install Dependencies on Windows

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,9 +4,8 @@ on: [push, pull_request]
 
 env:
   CARGO_TERM_COLOR: always
-  SCCACHE_LINK: https://github.com/mozilla/sccache/releases/download
-  SCCACHE_VERSION: v0.3.0
   SHELL: /bin/bash
+  SCCACHE_VERSION: "v0.4.0"
 
 jobs:
   Build:
@@ -19,27 +18,30 @@ jobs:
         include:
           - os: windows-latest
             id: windows
-            sccache-path: C:\Users\runneradmin\Mozilla\sccache
           - os: macos-latest
             id: macos
-            sccache-path: /Users/runner/Library/Caches/Mozilla.sccache
           - os: ubuntu-latest
             id: linux
-            sccache-path: /home/runner/.cache/sccache
     env:
       CCACHE: sccache
       SCCACHE_CACHE_SIZE: 3G
-      SCCACHE_DIR: ${{ matrix.sccache-path }}
+      SCCACHE_GHA_ENABLED: "true"
+      CARGO_INCREMENTAL: 0
 
     steps:
-      - uses: actions/checkout@v2
-
+      - uses: actions/checkout@v3
+      
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Get LLVM version from rustc
+        run: |
+          echo "LLVM_VERSION=$(rustc -vV | sed -n 's|LLVM version: ||p' | cut -d. -f1)" >> $GITHUB_ENV
+        shell: bash
+        
       - name: Install Dependencies on Windows
         if: matrix.id == 'windows'
         env:
           MOZILLA_BUILD_LINK: https://ftp.mozilla.org/pub/mozilla/libraries/win32
           MOZILLA_BUILD_VERSION: 3.4
-          LLVM_VERSION: 14.0.6
         run: |
           Start-BitsTransfer -Source $env:MOZILLA_BUILD_LINK/MozillaBuildSetup-$env:MOZILLA_BUILD_VERSION.exe -Destination ./MozillaBuildSetup.exe
           .\MozillaBuildSetup.exe /S | Out-Null
@@ -68,25 +70,12 @@ jobs:
         if: matrix.id == 'linux'
         run: |
           sudo apt install autoconf2.13 clang llvm -y
-          SCCACHE_FILE=sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl
-          mkdir -p $HOME/.local/bin
-          curl -L "$SCCACHE_LINK/$SCCACHE_VERSION/$SCCACHE_FILE.tar.gz" | tar xz
-          chmod +x $SCCACHE_FILE/sccache
-          mv -f $SCCACHE_FILE/sccache $HOME/.local/bin/sccache
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-      - name: Install Rust Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
-          default: true
       - name: Install Just
         uses: extractions/setup-just@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+      
       - name: Cache Cargo Cache and Git Database
         uses: actions/cache@v2
         with:
@@ -96,16 +85,11 @@ jobs:
           key: cargo-${{ matrix.id }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             cargo-${{ matrix.id }}-
-      - name: Cache sccache Cache
-        uses: actions/cache@v2
+          
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.3
         with:
-          path: ${{ matrix.sccache-path }}
-          key: sccache-${{ matrix.id }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            sccache-${{ matrix.id }}-
-
-      - name: Start sccache Server
-        run: sccache --start-server
+          version: ${{ env.SCCACHE_VERSION }}
 
       - name: Build POSIX
         if: matrix.id == 'macos' || matrix.id == 'linux'
@@ -137,11 +121,6 @@ jobs:
           just test-release -vv
           rename .\target\release\cli.exe spiderfire.exe
 
-      - name: Stop sccache Server
-        run: |
-          sccache --show-stats
-          sccache --stop-server || true
-
       - name: Upload Executables as Artifacts
         uses: actions/upload-artifact@v2
         if: matrix.rust == 'stable'
@@ -155,27 +134,16 @@ jobs:
     env:
       CCACHE: sccache
       SCCACHE_CACHE_SIZE: 1G
-      SCCACHE_DIR: /home/runner/.cache/sccache
+      SCCACHE_GHA_ENABLED: "true"
+      CARGO_INCREMENTAL: 0
 
     steps:
       - uses: actions/checkout@v2
+      - uses: dtolnay/rust-toolchain@stable
       - name: Install Dependencies on Linux
         run: |
           sudo apt install autoconf2.13 clang llvm -y
-          SCCACHE_FILE=sccache-$SCCACHE_VERSION-x86_64-unknown-linux-musl
-          mkdir -p $HOME/.local/bin
-          curl -L "$SCCACHE_LINK/$SCCACHE_VERSION/$SCCACHE_FILE.tar.gz" | tar xz
-          chmod +x $SCCACHE_FILE/sccache
-          mv -f $SCCACHE_FILE/sccache $HOME/.local/bin/sccache
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-      - name: Install Rust Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          default: true
+  
       - name: Install Just
         uses: extractions/setup-just@v1
         env:
@@ -190,16 +158,10 @@ jobs:
           key: cargo-lint-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             cargo-lint-
-      - name: Cache sccache Cache
-        uses: actions/cache@v2
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.3
         with:
-          path: /home/runner/.cache/sccache
-          key: sccache-lint-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            sccache-lint-
-
-      - name: Start sccache Server
-        run: sccache --start-server
+          version: ${{ env.SCCACHE_VERSION }}
 
       - name: Lint
         env:
@@ -208,8 +170,3 @@ jobs:
           RUSTC_WRAPPER: sccache
         run: |
           just lint
-
-      - name: Stop sccache Server
-        run: |
-          sccache --show-stats
-          sccache --stop-server || true


### PR DESCRIPTION
Use official sccache action and sccache v4.0.0 with GHA cache support.

Windows LLVM version is now fixated to rustc's LLVM version.