### PR TITLE
Fix class names not being null-terminated

### DIFF
--- a/ion/src/class.rs
+++ b/ion/src/class.rs
@@ -6,6 +6,7 @@
 
 use std::any::TypeId;
 use std::collections::hash_map::Entry;
+use std::ffi::CString;
 use std::ptr;
 
 use mozjs::glue::JS_GetReservedSlot;
@@ -75,13 +76,15 @@ pub trait ClassDefinition {
 				let static_properties = Self::static_properties();
 				let static_functions = Self::static_functions();
 
+				let name = CString::new(Self::NAME).unwrap();
+
 				let class = unsafe {
 					JS_InitClass(
 						cx.as_ptr(),
 						object.handle().into(),
 						parent_class,
 						parent_proto.handle().into(),
-						Self::NAME.as_ptr().cast(),
+						name.as_ptr().cast(),
 						Some(constructor),
 						nargs,
 						properties.as_ptr(),


### PR DESCRIPTION
The call to `JS_InitClass` was using `Self::NAME.as_ptr()` which is a rust string and is not properly null-terminated, resulting in class names overflowing into neighboring data resulting in names such as:

```
String("ExecuteRequestUninitialised Class/Users/arshia/.cargo/git/checkouts/mozjs-e1c76167ba7c548f/64ac49f/mozjs-sys/src/jsval.rsassertion failed: self.is_double()")
String("FetchEventUninitialised Class/Users/arshia/.cargo/git/checkouts/mozjs-e1c76167ba7c548f/64ac49f/mozjs-sys/src/jsval.rsassertion failed: self.is_double()")
```

This PR uses a CString to fix the issue.