### PR TITLE
Fix URL constructor when called with base argument

### DIFF
--- a/runtime/src/globals/url/mod.rs
+++ b/runtime/src/globals/url/mod.rs
@@ -38,10 +38,11 @@ pub struct URL {
 impl URL {
 	#[ion(constructor)]
 	pub fn constructor(#[ion(this)] this: &Object, cx: &Context, input: String, base: Option<String>) -> Result<URL> {
-		let options = Url::options();
-		let base = base.as_ref().and_then(|base| Url::parse(base).ok());
-		options.base_url(base.as_ref());
-		let url = options.parse(&input).map_err(|error| Error::new(&error.to_string(), None))?;
+		let base = base.as_ref().and_then(|base| url::Url::parse(base).ok());
+		let url = url::Url::options()
+			.base_url(base.as_ref())
+			.parse(&input)
+			.map_err(|error| Error::new(&error.to_string(), None))?;
 
 		let search_params = Box::new(URLSearchParams::new(url.query_pairs().into_owned().collect()));
 		search_params.url.as_ref().unwrap().set(this.handle().get());


### PR DESCRIPTION
This PR fixes constructing a URL with a base. Since `Url::options` is meant to be used with fluent syntax, calling `options.base_url` without storing the result has no effect.

Confusingly, `ParseOptions` implements `Copy`, which prevented this error from being caught by the compiler.